### PR TITLE
Fix to download "all"

### DIFF
--- a/geoLid/geoLid.py
+++ b/geoLid/geoLid.py
@@ -56,7 +56,7 @@ def download_model(model = "all", data_dir = None):
             url = model_list[name]
             
             #Download to the data directory
-            urllib.request.urlretrieve(url, os.path.join(data_dir, model))
+            urllib.request.urlretrieve(url, os.path.join(data_dir, "geolid."+name+".bin"))
     
     print("Finished downloading to ", os.path.join(data_dir))
 #-----------------------------------------------------------------------------------------------


### PR DESCRIPTION
When downloading using the keyword 'all' it downloads each model as the file name `all`. As it loops through the files it overwrites itself and at the end only one model is saved with a name the package does not expect. This fixes that and saves each model individually with the expected name.